### PR TITLE
plugin/motd.plg: fix wrong package uninstall

### DIFF
--- a/plugin/motd.plg
+++ b/plugin/motd.plg
@@ -59,7 +59,7 @@ The 'remove' script.
 <FILE Run="/bin/bash" Method="remove">
 <INLINE>
 <![CDATA[
-removepkg unraid-figurine
+removepkg unraid-motd
 
 rm -f /usr/local/bin/figurine
 


### PR DESCRIPTION
I think this is mostly a typo, but uninstallation currently fails as it's coded to uninstall `unraid-figurine` (which is not a Slackware package) and `unraid-motd` remains - this PR fixes that. Might need to push this as an update too, as people on the current version of the plugin won't be able to uninstall it cleanly (without reboot).